### PR TITLE
Fix read and close not declared error when build with g++

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include <fcntl.h>
 #include <ncurses.h>
+#include <unistd.h>
 #include "gtuna.hpp"
 
 using std::cout;


### PR DESCRIPTION
Hi, I cloned your repo and trying to build the code on Gentoo with g++ 4.9.4 I got this error due to a lack of unistd.h lib:

```
g++ -o gtuna dsp.cpp fft.cpp main.cpp -lm -lfftw3 -lncurses -g
main.cpp: In function ‘int main()’:
main.cpp:68:32: error: ‘read’ was not declared in this scope
    if (read (dsp, data, bufsize) < 0)
                                ^
main.cpp:153:11: error: ‘close’ was not declared in this scope
  close(dsp);
           ^
make: *** [Makefile:2: all] Error 1
```

Here the pull request with the change fix.
Bye